### PR TITLE
Conditional compilation for Windows

### DIFF
--- a/cbits/byteorder.c
+++ b/cbits/byteorder.c
@@ -2,7 +2,12 @@
    implemented as macros only, so I have to re-export functions here to do the
    conversions. */
 
-#include <arpa/inet.h>
+#if defined(WINDOWS)
+#  include <winsock2.h>
+#  include <inttypes.h>
+#else
+#  include <arpa/inet.h>
+#endif
 
 uint32_t iostreams_htonl(uint32_t hostlong) {
     return htonl(hostlong);

--- a/io-streams-haproxy.cabal
+++ b/io-streams-haproxy.cabal
@@ -41,6 +41,9 @@ library
   ghc-options:       -Wall -fwarn-tabs -funbox-strict-fields -threaded
                      -fno-warn-unused-do-bind
   ghc-prof-options:  -prof -auto-all
+  if os(windows)
+    cpp-options:     -DWINDOWS
+    cc-options:      -DWINDOWS
 
 test-suite testsuite
   type:              exitcode-stdio-1.0
@@ -66,3 +69,6 @@ test-suite testsuite
                      HUnit                      >= 1.2      && <2,
                      test-framework             >= 0.8.0.3  && <0.9,
                      test-framework-hunit       >= 0.2.7    && <0.4
+  if os(windows)
+    cpp-options:     -DWINDOWS
+    cc-options:      -DWINDOWS


### PR DESCRIPTION
Fix build on Windows without using configure by using cabal directives. See #5
and #6.