### PR TITLE
Allow network-2.8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+.ghc.environment.*
 cabal.project.local
 dist-newstyle/
 TAGS

--- a/io-streams-haproxy.cabal
+++ b/io-streams-haproxy.cabal
@@ -39,7 +39,7 @@ library
                      attoparsec        >= 0.7 && < 0.14,
                      bytestring        >= 0.9 && < 0.11,
                      io-streams        >= 1.3 && < 1.6,
-                     network           >= 2.3 && < 2.8,
+                     network           >= 2.3 && < 2.9,
                      transformers      >= 0.3 && < 0.6
   default-language:  Haskell2010
 


### PR DESCRIPTION
The only silently breaking change in this release concerns the `Ord` instance for `PortNumber`, which doesn't seem to be used by `io-streams-haproxy`.