### PR TITLE
GHC 8.8.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-8.8.1"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.6.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.1], sources: [hvr-ghc]}}

--- a/io-streams-haproxy.cabal
+++ b/io-streams-haproxy.cabal
@@ -23,7 +23,7 @@ extra-source-files:
 cabal-version:       >=1.10
 Bug-Reports:         https://github.com/snapframework/io-streams-haproxy/issues
 Tested-With:         GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3,
-                     GHC == 8.0.1, GHC == 8.2.1, GHC == 8.4.3, GHC == 8.6.1
+                     GHC == 8.0.1, GHC == 8.2.1, GHC == 8.4.3, GHC == 8.6.1, GHC == 8.8.1
 
 source-repository head
   type:     git
@@ -35,7 +35,7 @@ library
   other-modules:     System.IO.Streams.Network.Internal.Address
   c-sources:         cbits/byteorder.c
 
-  build-depends:     base              >= 4.5 && < 4.13,
+  build-depends:     base              >= 4.5 && < 4.14,
                      attoparsec        >= 0.7 && < 0.14,
                      bytestring        >= 0.9 && < 0.11,
                      io-streams        >= 1.3 && < 1.6,


### PR DESCRIPTION
GHC 8.8.1 works out of the box so the only change is increased upperbound for base from `4.13` to `4.14`.