### PR TITLE
bump `base` bound for GHC 9

### DIFF
--- a/io-streams-haproxy.cabal
+++ b/io-streams-haproxy.cabal
@@ -36,7 +36,7 @@ library
   other-modules:     System.IO.Streams.Network.Internal.Address
   c-sources:         cbits/byteorder.c
 
-  build-depends:     base              >= 4.5 && < 4.15,
+  build-depends:     base              >= 4.5 && < 4.16,
                      attoparsec        >= 0.7 && < 0.14,
                      bytestring        >= 0.9 && < 0.11,
                      io-streams        >= 1.3 && < 1.6,


### PR DESCRIPTION
Seems to work
```
Running 1 test suites...
Test suite testsuite: RUNNING...
Test suite testsuite: PASS
1 of 1 test suites (1 of 1 test cases) passed.
```